### PR TITLE
Reference the component-model async proposal as the future of polling.

### DIFF
--- a/wasi-poll.html
+++ b/wasi-poll.html
@@ -18,9 +18,9 @@ that they do not outlive the resource they reference.</p>
 <p>The &quot;oneoff&quot; in the name refers to the fact that this function must do a
 linear scan through the entire list of subscriptions, which may be
 inefficient if the number is large and the same subscriptions are used
-many times. In the future, it may be accompanied by an API similar to
-Linux's <code>epoll</code> which allows sets of subscriptions to be registered and
-made efficiently reusable.</p>
+many times. In the future, this is expected to be obsoleted by the
+component model async proposal, which will include a scalable waiting
+facility.</p>
 <p>Note that the return type would ideally be <code>list&lt;bool&gt;</code>, but that would
 be more difficult to polyfill given the current state of <code>wit-bindgen</code>.
 See https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061

--- a/wasi-poll.md
+++ b/wasi-poll.md
@@ -30,9 +30,9 @@ Poll for completion on a set of pollables.
 The "oneoff" in the name refers to the fact that this function must do a
 linear scan through the entire list of subscriptions, which may be
 inefficient if the number is large and the same subscriptions are used
-many times. In the future, it may be accompanied by an API similar to
-Linux's `epoll` which allows sets of subscriptions to be registered and
-made efficiently reusable.
+many times. In the future, this is expected to be obsoleted by the
+component model async proposal, which will include a scalable waiting
+facility.
 
 Note that the return type would ideally be `list<bool>`, but that would
 be more difficult to polyfill given the current state of `wit-bindgen`.

--- a/wit/wasi-poll.wit.md
+++ b/wit/wasi-poll.wit.md
@@ -37,9 +37,9 @@ drop-pollable: func(this: pollable)
 /// The "oneoff" in the name refers to the fact that this function must do a
 /// linear scan through the entire list of subscriptions, which may be
 /// inefficient if the number is large and the same subscriptions are used
-/// many times. In the future, it may be accompanied by an API similar to
-/// Linux's `epoll` which allows sets of subscriptions to be registered and
-/// made efficiently reusable.
+/// many times. In the future, this is expected to be obsoleted by the
+/// component model async proposal, which will include a scalable waiting
+/// facility.
 ///
 /// Note that the return type would ideally be `list<bool>`, but that would
 /// be more difficult to polyfill given the current state of `wit-bindgen`.


### PR DESCRIPTION
The plan is to focus on the [component-model async proposal], as part of Preview3, as the path to scalable polling, so remove the discussion of a hypothetical `epoll`-like API and just reference that directly.

[component-model async proposal]: https://docs.google.com/presentation/d/1MNVOZ8hdofO3tI0szg_i-Yoy0N2QPU2C--LzVuoGSlE/edit#slide=id.g1270ef7d5b6_0_662