### PR TITLE
update wit-abi to 0.11.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: WebAssembly/wit-abi-up-to-date@v12
+    - uses: WebAssembly/wit-abi-up-to-date@v13
       with:
-        wit-abi-tag: wit-abi-0.10.0
+        wit-abi-tag: wit-abi-0.11.0

--- a/example-world.md
+++ b/example-world.md
@@ -2,11 +2,11 @@
 <ul>
 <li>Imports:
 <ul>
-<li>interface <a href="#poll"><code>poll</code></a></li>
+<li>interface <a href="#wasi:poll_poll"><code>wasi:poll/poll</code></a></li>
 </ul>
 </li>
 </ul>
-<h2><a name="poll">Import interface poll</a></h2>
+<h2><a name="wasi:poll_poll">Import interface wasi:poll/poll</a></h2>
 <p>A poll API intended to let users wait for I/O events on multiple handles
 at once.</p>
 <hr />


### PR DESCRIPTION
Update the CI check, and regenerate example-world.md with the latest wit-abi release, which groks the wit syntax changes.