### PR TITLE
Improve the documentation for `poll-oneoff`.

### DIFF
--- a/example-world.md
+++ b/example-world.md
@@ -34,15 +34,20 @@ be used.</p>
 </ul>
 <h4><a name="poll_oneoff"><code>poll-oneoff: func</code></a></h4>
 <p>Poll for completion on a set of pollables.</p>
+<p>This function takes a list of pollables, which identify I/O sources of
+interest, and waits until one or more of the events is ready for I/O.</p>
+<p>The result <code>list&lt;bool&gt;</code> is the same length as the argument
+<code>list&lt;pollable&gt;</code>, and indicates the readiness of each corresponding
+element in that list, with true indicating ready. A single call can
+return multiple true elements.</p>
+<p>A timeout can be implemented by adding a pollable from the
+wasi-clocks API to the list.</p>
 <p>The &quot;oneoff&quot; in the name refers to the fact that this function must do a
 linear scan through the entire list of subscriptions, which may be
 inefficient if the number is large and the same subscriptions are used
 many times. In the future, this is expected to be obsoleted by the
 component model async proposal, which will include a scalable waiting
 facility.</p>
-<p>The result list<bool> is the same length as the argument
-list<pollable>, and indicates the readiness of each corresponding
-element in that / list, with true indicating ready.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="poll_oneoff.in"><code>in</code></a>: list&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>

--- a/example-world.md
+++ b/example-world.md
@@ -42,6 +42,10 @@ element in that list, with true indicating ready. A single call can
 return multiple true elements.</p>
 <p>A timeout can be implemented by adding a pollable from the
 wasi-clocks API to the list.</p>
+<p>This function does not return a <code>result</code>; polling in itself does not
+do any I/O so it doesn't fail. If any of the I/O sources identified by
+the pollables has an error, it is indicated by marking the source as
+ready in the <code>list&lt;bool&gt;</code>.</p>
 <p>The &quot;oneoff&quot; in the name refers to the fact that this function must do a
 linear scan through the entire list of subscriptions, which may be
 inefficient if the number is large and the same subscriptions are used

--- a/wit/poll.wit
+++ b/wit/poll.wit
@@ -23,15 +23,22 @@ interface poll {
 
     /// Poll for completion on a set of pollables.
     ///
+    /// This function takes a list of pollables, which identify I/O sources of
+    /// interest, and waits until one or more of the events is ready for I/O.
+    ///
+    /// The result `list<bool>` is the same length as the argument
+    /// `list<pollable>`, and indicates the readiness of each corresponding
+    /// element in that list, with true indicating ready. A single call can
+    /// return multiple true elements.
+    ///
+    /// A timeout can be implemented by adding a pollable from the
+    /// wasi-clocks API to the list.
+    ///
     /// The "oneoff" in the name refers to the fact that this function must do a
     /// linear scan through the entire list of subscriptions, which may be
     /// inefficient if the number is large and the same subscriptions are used
     /// many times. In the future, this is expected to be obsoleted by the
     /// component model async proposal, which will include a scalable waiting
     /// facility.
-    ///
-    /// The result list<bool> is the same length as the argument
-    /// list<pollable>, and indicates the readiness of each corresponding
-    /// element in that / list, with true indicating ready.
     poll-oneoff: func(in: list<pollable>) -> list<bool>
 }

--- a/wit/poll.wit
+++ b/wit/poll.wit
@@ -34,6 +34,11 @@ interface poll {
     /// A timeout can be implemented by adding a pollable from the
     /// wasi-clocks API to the list.
     ///
+    /// This function does not return a `result`; polling in itself does not
+    /// do any I/O so it doesn't fail. If any of the I/O sources identified by
+    /// the pollables has an error, it is indicated by marking the source as
+    /// ready in the `list<bool>`.
+    ///
     /// The "oneoff" in the name refers to the fact that this function must do a
     /// linear scan through the entire list of subscriptions, which may be
     /// inefficient if the number is large and the same subscriptions are used


### PR DESCRIPTION
More clearly describe what `poll-oneoff` does, mention that multiple events can be indicated ready at the same time, and mention that a timeout can be added by obtaining a pollable from wasi-clocks.